### PR TITLE
Fixes to run out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ wget https://satclip.z13.web.core.windows.net/satclip/satclip.tar
 tar -xf satclip.tar
 ```
 
-Now, to train **SatCLIP** models, set the paths correctly, adapt training configs in `clip/configs/default.yaml` and train SatCLIP by running:
+Now, to train **SatCLIP** models, set the paths correctly, adapt training configs in `satclip/configs/default.yaml` and train SatCLIP by running:
 ```bash
-python satclip/main.py
+cd satclip
+python main.py
 ```
 
 ### Use of the S2-100K dataset
@@ -60,12 +61,12 @@ The S2-100K dataset is a dataset of 100,000 multi-spectral satellite images samp
 *Visualization of embeddings obtained by different location encoders for locations around the globe.*
 
 We provide six pretrained SatCLIP models, trained with different vision encoders and spatial resolution hyperparameters $L$ (these indicate the number of Legendre polynomials used for spherical harmonics location encoding. Please refer to our paper for more details). The pretrained models can be downloaded as follows:
-* SatCLIP-ResNet18-L10: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet18-l10.ckpt` 
-* SatCLIP-ResNet18-L40: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet18-l40.ckpt` 
-* SatCLIP-ResNet50-L10: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet50-l10.ckpt` 
-* SatCLIP-ResNet50-L40: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet50-l40.ckpt` 
-* SatCLIP-ViT16-L10: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-vit16-l10.ckpt` 
-* SatCLIP-ViT16-L40: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-vit16-l40.ckpt` 
+* SatCLIP-ResNet18-L10: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet18-l10.ckpt`
+* SatCLIP-ResNet18-L40: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet18-l40.ckpt`
+* SatCLIP-ResNet50-L10: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet50-l10.ckpt`
+* SatCLIP-ResNet50-L40: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-resnet50-l40.ckpt`
+* SatCLIP-ViT16-L10: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-vit16-l10.ckpt`
+* SatCLIP-ViT16-L40: `wget https://satclip.z13.web.core.windows.net/satclip/satclip-vit16-l40.ckpt`
 
 Usage of pretrained models is simple:
 ```python
@@ -127,8 +128,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/satclip/.gitignore
+++ b/satclip/.gitignore
@@ -1,0 +1,5 @@
+# SatCLIP files
+satclip_logs/
+
+# Python
+__pycache__/

--- a/satclip/configs/default.yaml
+++ b/satclip/configs/default.yaml
@@ -20,7 +20,7 @@ model:
   vision_layers: 4
   vision_width: 128
   vision_patch_size: 32
-  in_channels: 4
+  in_channels: 13
   le_type: 'sphericalharmonics'
   frequency_num: 16
   max_radius: 0.01


### PR DESCRIPTION
# Description
This PR updates documentation and code to run out of the box for new users.

## Issue 1
The training script `main.py` expects configurations to be in the relative `./configs/` directory inside `satclip` (and seems to default erroneously to `/configs/default.yaml`). The default README  command `python satclip/main.py` thus results in the config not being found:
```shell
RuntimeError: Dataset not found or corrupted.
```
**Resolution:** the correct command in the README would be to run `python main.py` from the `satclip` directory.

## Issue 2
Fixing the above, Lightning is then not able to create the configs subdirectory structure. Indeed, Lightning expects the configuration file to just be a filename, not a path to a config file (including subdirectories).
```shell
jsonargparse._util.PathError: File is not creatable since parent directory does not exist: '/home/user/satclip/satclip/satclip_logs/satclip/satclip/./configs/default-latest.yaml'
```
**Resolution:** This PR creates the configs subdirectory structure inside the logs directory so that the user does not have to do it manually upon first run.

## Issue 3
The default config uses `in_channels: 4` for SatCLIP, but the S2-100k dataset requires 13 channels. 
```shell
RuntimeError: Given groups=1, weight of size [128, 4, 32, 32], expected input[128, 13, 256, 256] to have 4 channels, but got 13 channels instead
```
**Resolution:** this PR updates the `default.yaml` config to use 13 input channels.
## Expected behavior
The code runs correctly out of the box when following the README instructions.

## Steps to reproduce
```shell
cd /tmp
git clone https://github.com/microsoft/satclip.git
cd satclip
python satclip/main.py
```

# Testing
:heavy_check_mark:  I cloned this branch fresh in a new directory, and ran the new README instructions. This results in successfully starting the training script without errors:
```shell
$ python main.py 
Seed set to 0
using vision transformer
GPU available: True (cuda), used: True
TPU available: False, using: 0 TPU cores
HPU available: False, using: 0 HPUs
skipped 8142/100000 images because they were smaller than 10000 bytes... they probably contained nodata pixels
LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]

  | Name     | Type        | Params | Mode 
-------------------------------------------------
0 | model    | SatCLIP     | 2.9 M  | train
1 | loss_fun | SatCLIPLoss | 0      | train
-------------------------------------------------
2.9 M     Trainable params
0         Non-trainable params
2.9 M     Total params
11.731    Total estimated model params size (MB)
Epoch 0:   4%|████                                                                                                           | 24/646 [00:19<08:20,  1.24it/s, v_num=clip]
```