### PR TITLE
Create Python package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Build & test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install torch (CPU)
+        # Install the CPU-only torch build first to keep CI lightweight and avoid
+        # pulling large CUDA wheels via transitive dependencies.
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package
+        run: pip install -e ".[dev,examples]"
+
+      - name: Import smoke test
+        run: python -c "import satclip; print('satclip public API:', satclip.__all__)"
+
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ satclip_logs/
 
 # Python
 __pycache__/
+*.egg-info/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ satclip_logs/
 __pycache__/
 *.egg-info/
 build/
+dist/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -8,13 +8,27 @@
 
 SatCLIP trains location and image encoders via contrastive learning, by matching images to their corresponding locations. This is analogous to the CLIP approach, which matches images to their corresponding text. Through this process, the location encoder learns characteristics of a location, as represented by satellite imagery. For more details, check out our [paper](https://arxiv.org/abs/2311.17179).
 
+## Installation
+
+SatCLIP is packaged as a Python module. Install it directly from GitHub:
+```bash
+pip install git+https://github.com/microsoft/satclip.git
+```
+Or, for a local/editable install (e.g. for training or development):
+```bash
+git clone https://github.com/microsoft/satclip.git
+cd satclip
+pip install -e .
+```
+Once installed, `satclip` can be imported from any directory — no need to set `PYTHONPATH`.
+
 ## Overview
 
 Usage of SatCLIP is simple:
 
 ```python
-from model import *
-from location_encoder import *
+import torch
+from satclip.model import SatCLIP
 
 model = SatCLIP(
     embed_dim=512,
@@ -48,11 +62,11 @@ mkdir -p images
 for f in data/shard-*.tar; do tar -xf "$f" -C images; done
 ```
 
-Now, to train **SatCLIP** models, set the paths correctly (point `data.data_dir` in `satclip/configs/default.yaml` to this dataset directory), adapt training configs in `satclip/configs/default.yaml` and train SatCLIP by running:
+Now, to train **SatCLIP** models, set the paths correctly (point `data.data_dir` in `satclip/configs/default.yaml` to this dataset directory), adapt training configs in `satclip/configs/default.yaml` and train SatCLIP by running the training module from the repository root:
 ```bash
-cd satclip
-python main.py
+python -m satclip.main
 ```
+This requires an editable install (`pip install -e .`, see [Installation](#installation)). You can point to a custom config with `python -m satclip.main --config path/to/config.yaml`.
 
 ### Use of the S2-100K dataset
 
@@ -96,7 +110,7 @@ We provide six pretrained SatCLIP models, trained with different vision encoders
 Usage of pretrained models is simple. Simply specify the SatCLIP model you want to access, e.g. `satclip-vit16-l40`:
 ```python
 from huggingface_hub import hf_hub_download
-from load import get_satclip
+from satclip.load import get_satclip
 import torch
 
 device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/notebooks/A01_Simple_SatCLIP_Usage.ipynb
+++ b/notebooks/A01_Simple_SatCLIP_Usage.ipynb
@@ -51,8 +51,7 @@
         }
       ],
       "source": [
-        "!rm -r sample_data .config # Empty current directory\n",
-        "!git clone https://github.com/microsoft/satclip.git . # Clone SatCLIP repository"
+        "!pip install git+https://github.com/microsoft/satclip.git"
       ]
     },
     {
@@ -169,11 +168,8 @@
     {
       "cell_type": "code",
       "source": [
-        "import sys\n",
-        "sys.path.append('./satclip')\n",
-        "\n",
         "import torch\n",
-        "from load import get_satclip"
+        "from satclip.load import get_satclip"
       ],
       "metadata": {
         "id": "grEIwoFjoHvu"

--- a/notebooks/A02_SatCLIP_Hugging_Face_Usage.ipynb
+++ b/notebooks/A02_SatCLIP_Hugging_Face_Usage.ipynb
@@ -397,8 +397,7 @@
         }
       ],
       "source": [
-        "!rm -r sample_data .config # Empty current directory\n",
-        "!git clone https://github.com/microsoft/satclip.git . # Clone SatCLIP repository"
+        "!pip install git+https://github.com/microsoft/satclip.git"
       ]
     },
     {
@@ -473,11 +472,8 @@
     {
       "cell_type": "code",
       "source": [
-        "import sys\n",
-        "sys.path.append('./satclip')\n",
-        "\n",
         "import torch\n",
-        "from load import get_satclip"
+        "from satclip.load import get_satclip"
       ],
       "metadata": {
         "id": "grEIwoFjoHvu"
@@ -498,7 +494,7 @@
       "cell_type": "code",
       "source": [
         "from huggingface_hub import hf_hub_download\n",
-        "from load import get_satclip\n",
+        "from satclip.load import get_satclip\n",
         "import torch\n",
         "\n",
         "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",

--- a/notebooks/B01_Example_Air_Temperature_Prediction.ipynb
+++ b/notebooks/B01_Example_Air_Temperature_Prediction.ipynb
@@ -55,8 +55,7 @@
         }
       ],
       "source": [
-        "!rm -r sample_data .config # Empty current directory\n",
-        "!git clone https://github.com/microsoft/satclip.git . # Clone SatCLIP repository"
+        "!pip install git+https://github.com/microsoft/satclip.git"
       ]
     },
     {
@@ -168,11 +167,8 @@
     {
       "cell_type": "code",
       "source": [
-        "import sys\n",
-        "sys.path.append('./satclip')\n",
-        "\n",
         "import torch\n",
-        "from load import get_satclip\n",
+        "from satclip.load import get_satclip\n",
         "\n",
         "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu') # Automatically select device"
       ],

--- a/notebooks/B02_Example_Image_Localization.ipynb
+++ b/notebooks/B02_Example_Image_Localization.ipynb
@@ -399,8 +399,7 @@
         }
       ],
       "source": [
-        "!rm -r sample_data .config # Empty current directory\n",
-        "!git clone https://github.com/microsoft/satclip.git . # Clone SatCLIP repository"
+        "!pip install git+https://github.com/microsoft/satclip.git"
       ]
     },
     {
@@ -485,10 +484,7 @@
     {
       "cell_type": "code",
       "source": [
-        "import sys\n",
-        "sys.path.append('./satclip')\n",
-        "\n",
-        "from load import get_satclip\n",
+        "from satclip.load import get_satclip\n",
         "from huggingface_hub import hf_hub_download\n",
         "import torch\n",
         "from sklearn.metrics.pairwise import cosine_similarity\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "satclip"
+description = "A global, general-purpose geographic location encoder"
+version = "0.0.1"
+authors = [
+  {name="Konstantin Klemmer"},
+  {name="Esther Rolf"},
+  {name="Caleb Robinson"},
+  {name="Lester Mackey"},
+  {name="Marc Rußwurm"},
+]
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+    "License :: OSI Approved :: MIT License",
+]
+
+dependencies = [
+    "albumentations",
+    "lightning == 2.2.2",
+    "pandas",
+    "rasterio >= 1.3.10",
+    "torchgeo >= 0.5",  # Forces Python 3.9+
+]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/satclip"
+Repository = "https://github.com/microsoft/satclip.git"
+Issues = "https://github.com/microsoft/satclip/issues"
+
+[tool.setuptools.packages.find]
+include = ["satclip", "satclip.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,21 +14,48 @@ authors = [
   {name="Marc Rußwurm"},
 ]
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: MIT License",
 ]
 
+# Direct (first-order) imports of the `satclip` package. Versions of the heavier
+# scientific stack (numpy, sympy, torch, ...) are largely constrained by
+# torchgeo/lightning, but are listed explicitly so the package does not silently
+# rely on transitive dependencies.
 dependencies = [
     "albumentations",
-    "lightning == 2.2.2",
+    "einops",
+    "huggingface_hub",
+    "lightning >=2.2,<3",
+    "matplotlib",
+    "numpy",
     "pandas",
-    "rasterio >= 1.3.10",
-    "torchgeo >= 0.5",  # Forces Python 3.9+
+    "rasterio >=1.3.10",
+    "sympy",
+    "timm",
+    "torch >=1.13",
+    "torchgeo >=0.5",  # Forces Python 3.9+
+    "torchvision",
 ]
+
+[project.optional-dependencies]
+# Extra dependencies used by the example notebooks only.
+examples = [
+    "scikit-learn",
+]
+# Development / CI tooling.
+dev = [
+    "build",
+    "pytest",
+    "ruff",
+]
+
+[project.scripts]
+satclip-train = "satclip.main:cli_main"
 
 [project.urls]
 Homepage = "https://github.com/microsoft/satclip"
@@ -37,3 +64,7 @@ Issues = "https://github.com/microsoft/satclip/issues"
 
 [tool.setuptools.packages.find]
 include = ["satclip", "satclip.*"]
+
+[tool.setuptools.package-data]
+# Ship the default training config so `python -m satclip.main` works after install.
+satclip = ["configs/*.yaml"]

--- a/satclip/__init__.py
+++ b/satclip/__init__.py
@@ -1,5 +1,11 @@
-from . import *
-from .main import *
-from .model import *
-from .loss import *
-from .location_encoder import *
+"""SatCLIP: a global, general-purpose geographic location encoder.
+
+See https://github.com/microsoft/satclip for details.
+"""
+
+from .load import get_satclip
+from .location_encoder import LocationEncoder
+from .loss import SatCLIPLoss
+from .model import SatCLIP
+
+__all__ = ["SatCLIP", "LocationEncoder", "SatCLIPLoss", "get_satclip"]

--- a/satclip/load.py
+++ b/satclip/load.py
@@ -1,4 +1,4 @@
-from main import *
+from .main import *
 
 def get_satclip(ckpt_path, device, return_all=False):
     ckpt = torch.load(ckpt_path,map_location=device)

--- a/satclip/load_lightweight.py
+++ b/satclip/load_lightweight.py
@@ -1,5 +1,6 @@
 import torch
-from location_encoder import get_neural_network, get_positional_encoding, LocationEncoder
+
+from .location_encoder import get_neural_network, get_positional_encoding, LocationEncoder
 
 
 def get_satclip_loc_encoder(ckpt_path, device):
@@ -14,7 +15,7 @@ def get_satclip_loc_encoder(ckpt_path, device):
         hp['max_radius'],
         hp['frequency_num']
     )
-    
+
     nnet = get_neural_network(
         hp['pe_type'],
         posenc.embedding_dim,
@@ -25,12 +26,11 @@ def get_satclip_loc_encoder(ckpt_path, device):
 
     # only load nnet params from state dict
     state_dict = ckpt['state_dict']
-    state_dict = {k[k.index('nnet'):]:state_dict[k] 
+    state_dict = {k[k.index('nnet'):]:state_dict[k]
                   for k in state_dict.keys() if 'nnet' in k}
-    
+
     loc_encoder = LocationEncoder(posenc, nnet).double()
     loc_encoder.load_state_dict(state_dict)
     loc_encoder.eval()
 
     return loc_encoder
-        

--- a/satclip/location_encoder.py
+++ b/satclip/location_encoder.py
@@ -1,11 +1,11 @@
-from torch import nn, optim
 import math
+
 import torch
 import torch.nn.functional as F
 from einops import rearrange
-import numpy as np
-from datetime import datetime
-import positional_encoding as PE
+from torch import nn
+
+from . import positional_encoding as PE
 
 """
 FCNet
@@ -110,7 +110,7 @@ class SirenNet(nn.Module):
                 x *= rearrange(mod, 'd -> () d')
 
         return self.last_layer(x)
-    
+
 class Sine(nn.Module):
     def __init__(self, w0 = 1.):
         super().__init__()

--- a/satclip/main.py
+++ b/satclip/main.py
@@ -3,10 +3,11 @@ from pathlib import Path
 
 import lightning.pytorch
 import torch
-from datamodules.s2geo_dataset import S2GeoDataModule
 from lightning.pytorch.cli import LightningCLI
-from loss import SatCLIPLoss
-from model import SatCLIP
+
+from .datamodules.s2geo_dataset import S2GeoDataModule
+from .loss import SatCLIPLoss
+from .model import SatCLIP
 
 torch.set_float32_matmul_precision('high')
 

--- a/satclip/main.py
+++ b/satclip/main.py
@@ -11,6 +11,10 @@ from .model import SatCLIP
 
 torch.set_float32_matmul_precision('high')
 
+# Default training config shipped with the package; resolved relative to this
+# file so training works regardless of the current working directory.
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "configs" / "default.yaml"
+
 class SatCLIPLightningModule(lightning.pytorch.LightningModule):
     def __init__(
         self,
@@ -112,7 +116,9 @@ class MyLightningCLI(LightningCLI):
         parser.add_argument("--watchmodel", action="store_true")
 
 
-def cli_main(default_config_filename="./configs/default.yaml"):
+def cli_main(default_config_filename=None):
+    if default_config_filename is None:
+        default_config_filename = str(DEFAULT_CONFIG)
     save_config_fn = default_config_filename.replace(".yaml", "-latest.yaml")
     # modify configs/default.yaml for learning rate etc.
     cli = MyLightningCLI(
@@ -140,7 +146,7 @@ def cli_main(default_config_filename="./configs/default.yaml"):
 
     # Create folder to log configs
     # NOTE: Lightning does not handle config paths with subfolders
-    dirname_cfg = Path(default_config_filename).parent
+    dirname_cfg = Path(default_config_filename).parent.name
     dir_log_cfg = Path(cli.trainer.log_dir) / dirname_cfg
     dir_log_cfg.mkdir(parents=True, exist_ok=True)
 
@@ -151,12 +157,10 @@ def cli_main(default_config_filename="./configs/default.yaml"):
 
 
 if __name__ == "__main__":
-    config_fn = "./configs/default.yaml"
-
     #A100 go vroom vroom 🚗💨
-    if torch.cuda.get_device_name(device=0)=='NVIDIA A100 80GB PCIe':
+    if torch.cuda.is_available() and torch.cuda.get_device_name(device=0) == 'NVIDIA A100 80GB PCIe':
         torch.backends.cuda.matmul.allow_tf32 = True
         print('Superfastmode! 🚀')
     else:
         torch.backends.cuda.matmul.allow_tf32 = False
-    cli_main(config_fn)
+    cli_main()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,71 @@
+"""Smoke tests for the installed `satclip` package.
+
+These verify that the package imports cleanly (i.e. that intra-package imports
+resolve as a proper package) and that a small SatCLIP model can run a forward
+pass end to end.
+"""
+
+import torch
+
+import satclip
+from satclip.model import SatCLIP
+
+
+def test_public_api():
+    for name in ("SatCLIP", "LocationEncoder", "SatCLIPLoss", "get_satclip"):
+        assert hasattr(satclip, name), f"satclip.{name} should be importable"
+
+
+def test_satclip_forward():
+    model = SatCLIP(
+        embed_dim=128,
+        image_resolution=224,
+        in_channels=13,
+        vision_layers=2,
+        vision_width=64,
+        vision_patch_size=32,
+        le_type="sphericalharmonics",
+        pe_type="siren",
+        legendre_polys=10,
+        frequency_num=16,
+        max_radius=360,
+        min_radius=1,
+        harmonics_calculation="analytic",
+    )
+    model.eval()
+
+    img_batch = torch.randn(2, 13, 224, 224)
+    loc_batch = torch.randn(2, 2)
+
+    with torch.no_grad():
+        logits_per_image, logits_per_coord = model(img_batch, loc_batch)
+
+    assert logits_per_image.shape == (2, 2)
+    assert logits_per_coord.shape == (2, 2)
+
+
+def test_location_encoder_only():
+    """The location encoder should embed coordinates on its own."""
+    model = SatCLIP(
+        embed_dim=128,
+        image_resolution=224,
+        in_channels=13,
+        vision_layers=2,
+        vision_width=64,
+        vision_patch_size=32,
+        le_type="sphericalharmonics",
+        pe_type="siren",
+        legendre_polys=10,
+        frequency_num=16,
+        max_radius=360,
+        min_radius=1,
+        harmonics_calculation="analytic",
+    )
+    model.eval()
+
+    coords = torch.randn(4, 2)
+    with torch.no_grad():
+        emb = model.encode_location(coords)
+
+    assert emb.shape[0] == 4
+    assert emb.shape[1] == 128


### PR DESCRIPTION
# Description
The current setup seem to require that `satclip` be on a customized `$PYTHONPATH`, for example with:
```shell
export PYTHONPATH=${PYTHONPATH}:/path/to/satclip/satclip/
```

Moreover, it does not list dependencies and versioning (see Issue [Missing requirements.txt file #8](https://github.com/microsoft/satclip/issues/8))

This PR proposes to setup `satclip` as a Python package to install it just like any other Python package, and facilitating its use from any directory, without the need to setup the `PYTHONPATH`.

**Usage:** `pip install .`

**Example use cases:**
- Instantiate the `SatCLIP` PyTorch model: `from satclip.model import SatCLIP`
- Re-use parts of `satclip` in different training scripts `from satclip.location_encoder import LocationEncoder` or again `from satclip.main import SatCLIPLightningModule`

## PR changes
- Added a `pyproject.toml` using [setuptools](https://setuptools.pypa.io/en/latest/index.html#) as a build system, following the latest recommendations from [Python packaging](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
- Lists out main dependencies (albumentations, lightning, rasterio, torchgeo)
- Modified internal imports to be relative to `satclip` package directory

# Testing
- From the repo top directory `pip install .` runs succesfully
- Able to import `satclip` from any folder, without setting `$PYTHONPATH`:
```shell
$ cd ~
$ pwd
/home/user
$ echo $PYTHONPATH

$ python
Python 3.11.0 (main, Jul 29 2024, 13:47:50) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import satclip
/home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages/kornia/feature/lightglue.py:44: FutureWarning: `torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.
  @torch.cuda.amp.custom_fwd(cast_inputs=torch.float32)
>>>
```

<details>
  <summary><b>Example log output</b> (click to expand)</summary>
  Log from pip install .

  ```shell
$ pip install .
Processing /home/user/satclip
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting albumentations (from satclip==0.0.1)
  Using cached albumentations-1.4.13-py3-none-any.whl.metadata (38 kB)
Collecting lightning==2.2.2 (from satclip==0.0.1)
  Using cached lightning-2.2.2-py3-none-any.whl.metadata (53 kB)
Collecting pandas (from satclip==0.0.1)
  Using cached pandas-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (19 kB)
Collecting rasterio>=1.3.10 (from satclip==0.0.1)
  Using cached rasterio-1.3.10-cp311-cp311-manylinux2014_x86_64.whl.metadata (14 kB)
Collecting torchgeo>=0.5 (from satclip==0.0.1)
  Using cached torchgeo-0.5.2-py3-none-any.whl.metadata (20 kB)
Requirement already satisfied: PyYAML<8.0,>=5.4 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (6.0.2)
Requirement already satisfied: fsspec<2025.0,>=2022.5.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from fsspec[http]<2025.0,>=2022.5.0->lightning==2.2.2->satclip==0.0.1) (2024.2.0)
Requirement already satisfied: lightning-utilities<2.0,>=0.8.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (0.11.6)
Requirement already satisfied: numpy<3.0,>=1.17.2 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (1.26.3)
Requirement already satisfied: packaging<25.0,>=20.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (24.1)
Requirement already satisfied: torch<4.0,>=1.13.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (2.4.0+cu124)
Requirement already satisfied: torchmetrics<3.0,>=0.7.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (1.4.1)
Requirement already satisfied: tqdm<6.0,>=4.57.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (4.66.5)
Requirement already satisfied: typing-extensions<6.0,>=4.4.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (4.9.0)
Requirement already satisfied: pytorch-lightning in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning==2.2.2->satclip==0.0.1) (2.4.0)
Requirement already satisfied: affine in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (2.4.0)
Requirement already satisfied: attrs in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (24.2.0)
Requirement already satisfied: certifi in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (2024.7.4)
Requirement already satisfied: click>=4.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (8.1.7)
Requirement already satisfied: cligj>=0.5 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (0.7.2)
Requirement already satisfied: snuggs>=1.4.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (1.4.7)
Requirement already satisfied: click-plugins in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (1.1.1)
Requirement already satisfied: setuptools in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rasterio>=1.3.10->satclip==0.0.1) (65.5.0)
Requirement already satisfied: einops>=0.3 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (0.8.0)
Requirement already satisfied: fiona>=1.8.19 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (1.9.6)
Requirement already satisfied: kornia>=0.6.9 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (0.7.3)
Requirement already satisfied: lightly!=1.4.26,>=1.4.4 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (1.5.11)
Requirement already satisfied: matplotlib>=3.3.3 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (3.9.1.post1)
Requirement already satisfied: pillow>=8 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (10.2.0)
Requirement already satisfied: pyproj>=3 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (3.6.1)
Requirement already satisfied: rtree>=1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (1.3.0)
Requirement already satisfied: segmentation-models-pytorch>=0.2 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (0.3.3)
Requirement already satisfied: shapely>=1.7.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (2.0.5)
Requirement already satisfied: timm>=0.4.12 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (0.9.2)
Requirement already satisfied: torchvision>=0.13 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torchgeo>=0.5->satclip==0.0.1) (0.19.0+cu124)
Requirement already satisfied: python-dateutil>=2.8.2 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from pandas->satclip==0.0.1) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from pandas->satclip==0.0.1) (2024.1)
Requirement already satisfied: tzdata>=2022.7 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from pandas->satclip==0.0.1) (2024.1)
Requirement already satisfied: scipy>=1.10.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from albumentations->satclip==0.0.1) (1.14.0)
Requirement already satisfied: scikit-image>=0.21.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from albumentations->satclip==0.0.1) (0.24.0)
Requirement already satisfied: pydantic>=2.7.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from albumentations->satclip==0.0.1) (2.8.2)
Requirement already satisfied: albucore>=0.0.13 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from albumentations->satclip==0.0.1) (0.0.13)
Requirement already satisfied: eval-type-backport in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from albumentations->satclip==0.0.1) (0.2.0)
Requirement already satisfied: opencv-python-headless>=4.9.0.80 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from albumentations->satclip==0.0.1) (4.10.0.84)
Requirement already satisfied: tomli>=2.0.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from albucore>=0.0.13->albumentations->satclip==0.0.1) (2.0.1)
Requirement already satisfied: six in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from fiona>=1.8.19->torchgeo>=0.5->satclip==0.0.1) (1.16.0)
Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from fsspec[http]<2025.0,>=2022.5.0->lightning==2.2.2->satclip==0.0.1) (3.10.3)
Requirement already satisfied: kornia-rs>=0.1.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from kornia>=0.6.9->torchgeo>=0.5->satclip==0.0.1) (0.1.5)
Requirement already satisfied: hydra-core>=1.0.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (1.3.2)
Requirement already satisfied: lightly-utils~=0.0.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (0.0.2)
Requirement already satisfied: requests>=2.23.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (2.32.3)
Requirement already satisfied: urllib3>=1.25.3 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (2.2.2)
Requirement already satisfied: aenum>=3.1.11 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (3.1.15)
Requirement already satisfied: bitsandbytes==0.41.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (0.41.0)
Requirement already satisfied: jsonargparse<5.0,>=4.27.7 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from jsonargparse[signatures]<5.0,>=4.27.7; extra == "pytorch-extra"->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (4.32.0)
Requirement already satisfied: omegaconf<3.0,>=2.0.5 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (2.3.0)
Requirement already satisfied: rich<14.0,>=12.3.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (13.7.1)
Requirement already satisfied: tensorboardX<3.0,>=2.2 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (2.6.2.2)
Requirement already satisfied: contourpy>=1.0.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from matplotlib>=3.3.3->torchgeo>=0.5->satclip==0.0.1) (1.2.1)
Requirement already satisfied: cycler>=0.10 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from matplotlib>=3.3.3->torchgeo>=0.5->satclip==0.0.1) (0.12.1)
Requirement already satisfied: fonttools>=4.22.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from matplotlib>=3.3.3->torchgeo>=0.5->satclip==0.0.1) (4.53.1)
Requirement already satisfied: kiwisolver>=1.3.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from matplotlib>=3.3.3->torchgeo>=0.5->satclip==0.0.1) (1.4.5)
Requirement already satisfied: pyparsing>=2.3.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from matplotlib>=3.3.3->torchgeo>=0.5->satclip==0.0.1) (3.1.2)
Requirement already satisfied: annotated-types>=0.4.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from pydantic>=2.7.0->albumentations->satclip==0.0.1) (0.7.0)
Requirement already satisfied: pydantic-core==2.20.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from pydantic>=2.7.0->albumentations->satclip==0.0.1) (2.20.1)
Requirement already satisfied: networkx>=2.8 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from scikit-image>=0.21.0->albumentations->satclip==0.0.1) (3.2.1)
Requirement already satisfied: imageio>=2.33 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from scikit-image>=0.21.0->albumentations->satclip==0.0.1) (2.34.2)
Requirement already satisfied: tifffile>=2022.8.12 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from scikit-image>=0.21.0->albumentations->satclip==0.0.1) (2024.8.10)
Requirement already satisfied: lazy-loader>=0.4 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from scikit-image>=0.21.0->albumentations->satclip==0.0.1) (0.4)
Requirement already satisfied: pretrainedmodels==0.7.4 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from segmentation-models-pytorch>=0.2->torchgeo>=0.5->satclip==0.0.1) (0.7.4)
Requirement already satisfied: efficientnet-pytorch==0.7.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from segmentation-models-pytorch>=0.2->torchgeo>=0.5->satclip==0.0.1) (0.7.1)
Requirement already satisfied: huggingface-hub in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from timm>=0.4.12->torchgeo>=0.5->satclip==0.0.1) (0.24.5)
Requirement already satisfied: safetensors in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from timm>=0.4.12->torchgeo>=0.5->satclip==0.0.1) (0.4.4)
Requirement already satisfied: munch in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from pretrainedmodels==0.7.4->segmentation-models-pytorch>=0.2->torchgeo>=0.5->satclip==0.0.1) (4.0.0)
Requirement already satisfied: filelock in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (3.13.1)
Requirement already satisfied: sympy in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (1.12)
Requirement already satisfied: jinja2 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (3.1.3)
Requirement already satisfied: nvidia-cuda-nvrtc-cu12==12.4.99 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (12.4.99)
Requirement already satisfied: nvidia-cuda-runtime-cu12==12.4.99 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (12.4.99)
Requirement already satisfied: nvidia-cuda-cupti-cu12==12.4.99 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (12.4.99)
Requirement already satisfied: nvidia-cudnn-cu12==9.1.0.70 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (9.1.0.70)
Requirement already satisfied: nvidia-cublas-cu12==12.4.2.65 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (12.4.2.65)
Requirement already satisfied: nvidia-cufft-cu12==11.2.0.44 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (11.2.0.44)
Requirement already satisfied: nvidia-curand-cu12==10.3.5.119 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (10.3.5.119)
Requirement already satisfied: nvidia-cusolver-cu12==11.6.0.99 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (11.6.0.99)
Requirement already satisfied: nvidia-cusparse-cu12==12.3.0.142 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (12.3.0.142)
Requirement already satisfied: nvidia-nccl-cu12==2.20.5 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (2.20.5)
Requirement already satisfied: nvidia-nvtx-cu12==12.4.99 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (12.4.99)
Requirement already satisfied: nvidia-nvjitlink-cu12==12.4.99 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (12.4.99)
Requirement already satisfied: triton==3.0.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (3.0.0)
Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<2025.0,>=2022.5.0->lightning==2.2.2->satclip==0.0.1) (2.3.5)
Requirement already satisfied: aiosignal>=1.1.2 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<2025.0,>=2022.5.0->lightning==2.2.2->satclip==0.0.1) (1.3.1)
Requirement already satisfied: frozenlist>=1.1.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<2025.0,>=2022.5.0->lightning==2.2.2->satclip==0.0.1) (1.4.1)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<2025.0,>=2022.5.0->lightning==2.2.2->satclip==0.0.1) (6.0.5)
Requirement already satisfied: yarl<2.0,>=1.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<2025.0,>=2022.5.0->lightning==2.2.2->satclip==0.0.1) (1.9.4)
Requirement already satisfied: antlr4-python3-runtime==4.9.* in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from hydra-core>=1.0.0->lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (4.9.3)
Requirement already satisfied: docstring-parser>=0.15 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from jsonargparse[signatures]<5.0,>=4.27.7; extra == "pytorch-extra"->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (0.16)
Requirement already satisfied: typeshed-client>=2.1.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from jsonargparse[signatures]<5.0,>=4.27.7; extra == "pytorch-extra"->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (2.7.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from requests>=2.23.0->lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from requests>=2.23.0->lightly!=1.4.26,>=1.4.4->torchgeo>=0.5->satclip==0.0.1) (3.7)
Requirement already satisfied: markdown-it-py>=2.2.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rich<14.0,>=12.3.0->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (3.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from rich<14.0,>=12.3.0->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (2.18.0)
Requirement already satisfied: protobuf>=3.20 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from tensorboardX<3.0,>=2.2->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (5.27.3)
Requirement already satisfied: MarkupSafe>=2.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from jinja2->torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (2.1.5)
Requirement already satisfied: mpmath>=0.19 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from sympy->torch<4.0,>=1.13.0->lightning==2.2.2->satclip==0.0.1) (1.3.0)
Requirement already satisfied: mdurl~=0.1 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich<14.0,>=12.3.0->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (0.1.2)
Requirement already satisfied: importlib-resources>=1.4.0 in /home/user/.pyenv/versions/3.11.0/lib/python3.11/site-packages (from typeshed-client>=2.1.0->jsonargparse[signatures]<5.0,>=4.27.7; extra == "pytorch-extra"->lightning[pytorch-extra]>=2->torchgeo>=0.5->satclip==0.0.1) (6.4.0)
Using cached lightning-2.2.2-py3-none-any.whl (2.0 MB)
Using cached rasterio-1.3.10-cp311-cp311-manylinux2014_x86_64.whl (21.5 MB)
Using cached torchgeo-0.5.2-py3-none-any.whl (381 kB)
Using cached pandas-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (13.0 MB)
Using cached albumentations-1.4.13-py3-none-any.whl (171 kB)
Building wheels for collected packages: satclip
  Building wheel for satclip (pyproject.toml) ... done
  Created wheel for satclip: filename=satclip-0.0.1-py3-none-any.whl size=4017354 sha256=4e4af561efcaea8c268b353480d7a87f575904e9055dc0b653f15544292537c1
  Stored in directory: /tmp/pip-ephem-wheel-cache-fal20ggn/wheels/3e/73/bd/53cd44af9d38c274b7928db633e7a5b0a095d97c6ad8fe0686
Successfully built satclip
Installing collected packages: rasterio, pandas, albumentations, lightning, torchgeo, satclip
Successfully installed albumentations-1.4.13 lightning-2.2.2 pandas-2.2.2 rasterio-1.3.10 satclip-0.0.1 torchgeo-0.5.2
  ```
</details>